### PR TITLE
create, update, delete, fetch all source and fetch by source_id API with pytest

### DIFF
--- a/BACKEND/app/crud/sources.py
+++ b/BACKEND/app/crud/sources.py
@@ -1,77 +1,67 @@
 from sqlalchemy.orm import Session
-from uuid import UUID
-from sqlalchemy.exc import IntegrityError
-from fastapi import HTTPException, status
 from app.models.sources import Source
 from app.models.languages import Language
 from app.schemas.sources import SourceCreate, SourceUpdate
+from fastapi import HTTPException, status
+from uuid import UUID
 
 class SourceService:
-    def create_source(self, db: Session, source: SourceCreate) -> Source:
-        language = db.query(Language).filter(Language.id == source.language_id).first()
+    def create_source(self, db: Session, source_data: SourceCreate) -> Source:
+        language = db.query(Language).filter(Language.id == source_data.language_id).first()
         if not language:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Language with ID {source.language_id} not found"
+                detail=f"Language with ID {source_data.language_id} not found"
             )
 
-        new_source = Source(**source.dict())
-        try:
-            db.add(new_source)
-            db.commit()
-            db.refresh(new_source)
-            return new_source
-        except IntegrityError:
-            db.rollback()
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to create source"
-            )
-
-    def get_source(self, db: Session, source_id: UUID) -> Source:
-        source = db.query(Source).filter(Source.id == source_id).first()
-        if not source:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Source with ID {source_id} not found"
-            )
+        source = Source(
+            version_name=source_data.version_name,
+            version_abbreviation=source_data.version_abbreviation,
+            language_id=source_data.language_id,
+            language_name=language.name,  # auto-fill
+            description=source_data.description
+        )
+        db.add(source)
+        db.commit()
+        db.refresh(source)
         return source
 
-    def get_all_sources(self, db: Session):
+    def get_source(self, db: Session, source_id: UUID) -> Source:
+        source = db.query(Source).filter(Source.source_id == source_id).first()
+        if not source:
+            raise HTTPException(status_code=404, detail="Source not found")
+        return source
+
+    def get_all_sources(self, db: Session) -> list[Source]:
         return db.query(Source).all()
 
     def update_source(self, db: Session, source_id: UUID, update: SourceUpdate) -> Source:
-        source = self.get_source(db, source_id)
+        source = db.query(Source).filter(Source.source_id == source_id).first()
+        if not source:
+            raise HTTPException(status_code=404, detail="Source not found")
 
         if update.language_id:
             language = db.query(Language).filter(Language.id == update.language_id).first()
             if not language:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=f"Language with ID {update.language_id} not found"
-                )
+                raise HTTPException(status_code=404, detail="Language not found")
+            source.language_id = update.language_id
+            source.language_name = language.name  # update name too
 
-        for field, value in update.dict(exclude_unset=True).items():
-            setattr(source, field, value)
+        if update.version_name:
+            source.version_name = update.version_name
+        if update.version_abbreviation:
+            source.version_abbreviation = update.version_abbreviation
+        if update.description is not None:
+            source.description = update.description
 
-        try:
-            db.commit()
-            db.refresh(source)
-            return source
-        except IntegrityError:
-            db.rollback()
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to update source"
-            )
+        db.commit()
+        db.refresh(source)
+        return source
 
     def delete_source(self, db: Session, source_id: UUID) -> Source:
-        source = db.query(Source).filter(Source.id == source_id).first()
+        source = db.query(Source).filter(Source.source_id == source_id).first()
         if not source:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Source with ID {source_id} not found"
-            )
+            raise HTTPException(status_code=404, detail="Source not found")
         db.delete(source)
         db.commit()
         return source

--- a/BACKEND/app/crud/sources.py
+++ b/BACKEND/app/crud/sources.py
@@ -8,7 +8,17 @@ from uuid import UUID
 
 class SourceService:
     def create_source(self, db: Session, source_data: SourceCreate) -> Source:
-        # Fetch language
+        existing_source = db.query(Source).filter(
+            Source.language_id == source_data.language_id,
+            Source.version_id == source_data.version_id
+        ).first()
+        if existing_source:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Source with the given language and version already exists"
+            )
+
+    # Fetch language
         language = db.query(Language).filter(Language.language_id == source_data.language_id).first()
         if not language:
             raise HTTPException(
@@ -16,29 +26,29 @@ class SourceService:
                 detail=f"Language with ID {source_data.language_id} not found"
             )
 
-        # Fetch version
+    # Fetch version
         version = db.query(Version).filter(Version.version_id == source_data.version_id).first()
         if not version:
             raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Version with ID {source_data.version_id} not found"
-            )
-
-        # Create Source with auto-filled names
-        source = Source(
-            language_id=source_data.language_id,
-            language_name=language.name,
-            version_id=source_data.version_id,
-            version_name=version.version_name,
-            description=source_data.description,
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Version with ID {source_data.version_id} not found"
         )
+
+    # Create Source with auto-filled names
+        source = Source(
+        language_id=source_data.language_id,
+        language_name=language.name,
+        version_id=source_data.version_id,
+        version_name=version.version_name,
+        description=source_data.description,
+    )
 
         db.add(source)
         db.commit()
         db.refresh(source)
         return source
 
-    def get_source(self, db: Session, source_id: UUID) -> Source:
+    def get_source_by_id(self, db: Session, source_id: UUID) -> Source:
         source = db.query(Source).filter(Source.source_id == source_id).first()
         if not source:
             raise HTTPException(status_code=404, detail="Source not found")

--- a/BACKEND/app/crud/sources.py
+++ b/BACKEND/app/crud/sources.py
@@ -1,0 +1,79 @@
+from sqlalchemy.orm import Session
+from uuid import UUID
+from sqlalchemy.exc import IntegrityError
+from fastapi import HTTPException, status
+from app.models.sources import Source
+from app.models.languages import Language
+from app.schemas.sources import SourceCreate, SourceUpdate
+
+class SourceService:
+    def create_source(self, db: Session, source: SourceCreate) -> Source:
+        language = db.query(Language).filter(Language.id == source.language_id).first()
+        if not language:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Language with ID {source.language_id} not found"
+            )
+
+        new_source = Source(**source.dict())
+        try:
+            db.add(new_source)
+            db.commit()
+            db.refresh(new_source)
+            return new_source
+        except IntegrityError:
+            db.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to create source"
+            )
+
+    def get_source(self, db: Session, source_id: UUID) -> Source:
+        source = db.query(Source).filter(Source.id == source_id).first()
+        if not source:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Source with ID {source_id} not found"
+            )
+        return source
+
+    def get_all_sources(self, db: Session):
+        return db.query(Source).all()
+
+    def update_source(self, db: Session, source_id: UUID, update: SourceUpdate) -> Source:
+        source = self.get_source(db, source_id)
+
+        if update.language_id:
+            language = db.query(Language).filter(Language.id == update.language_id).first()
+            if not language:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Language with ID {update.language_id} not found"
+                )
+
+        for field, value in update.dict(exclude_unset=True).items():
+            setattr(source, field, value)
+
+        try:
+            db.commit()
+            db.refresh(source)
+            return source
+        except IntegrityError:
+            db.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to update source"
+            )
+
+    def delete_source(self, db: Session, source_id: UUID) -> Source:
+        source = db.query(Source).filter(Source.id == source_id).first()
+        if not source:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Source with ID {source_id} not found"
+            )
+        db.delete(source)
+        db.commit()
+        return source
+
+source_service = SourceService()

--- a/BACKEND/app/main.py
+++ b/BACKEND/app/main.py
@@ -1,7 +1,8 @@
 from fastapi import FastAPI, Depends
 from sqlalchemy.orm import Session
 from sqlalchemy import text
-from app.routes import users as user_routes  # rename to avoid conflict
+from app.routes import users as user_routes # rename to avoid conflict
+from app.routes import sources as source_routes
 from app.database import get_db, init_db_schema, Base, engine
 from contextlib import asynccontextmanager
 import logging
@@ -45,3 +46,4 @@ def ping_db(db: Session = Depends(get_db)):
 
 # --- Include API Routers ---
 app.include_router(user_routes.router, prefix="/users", tags=["users"])
+app.include_router(source_routes.router, prefix="/sources", tags=["sources"])

--- a/BACKEND/app/models/languages.py
+++ b/BACKEND/app/models/languages.py
@@ -1,0 +1,13 @@
+from sqlalchemy import Column, String, DateTime
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import func
+import uuid
+from app.database import Base
+
+class Language(Base):
+    __tablename__ = "languages"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name = Column(String(100), nullable=False)
+    code = Column(String(10), unique=True, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/BACKEND/app/models/sources.py
+++ b/BACKEND/app/models/sources.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Column, String, DateTime, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
+from uuid import uuid4
+from datetime import datetime
+from app.database import Base
+from app.models import languages
+
+class Source(Base):
+    __tablename__ = "sources"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4, index=True)
+    source_language = Column(String(100), nullable=False)
+    version_name = Column(String(100), nullable=False)
+    version_abbreviation = Column(String(100), nullable=False)
+    language_id = Column(UUID(as_uuid=True), ForeignKey("languages.id"), nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow)

--- a/BACKEND/app/models/sources.py
+++ b/BACKEND/app/models/sources.py
@@ -1,19 +1,19 @@
-from sqlalchemy import Column, String, Text, DateTime, ForeignKey
+from sqlalchemy import Column, String, Text, Boolean, DateTime, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import func
-from app.database import Base
 import uuid
+
+from app.database import Base
 
 class Source(Base):
     __tablename__ = "sources"
 
     source_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    version_name = Column(String(100), nullable=False)
-    version_abbreviation = Column(String(100), nullable=False)
-
-    language_id = Column(UUID(as_uuid=True), ForeignKey("languages.id", ondelete="RESTRICT"), nullable=False)
-    language_name = Column(String(100), nullable=False)  # denormalized field
-
+    language_id = Column(UUID(as_uuid=True), ForeignKey("languages.language_id"))
+    language_name = Column(String(255), nullable=False)
+    version_id = Column(UUID(as_uuid=True), ForeignKey("versions.version_id"))
+    version_name = Column(String(255), nullable=False)
     description = Column(Text)
-    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    is_active = Column(Boolean, nullable=False, default=True)

--- a/BACKEND/app/models/sources.py
+++ b/BACKEND/app/models/sources.py
@@ -1,17 +1,19 @@
-from sqlalchemy import Column, String, DateTime, ForeignKey
+from sqlalchemy import Column, String, Text, DateTime, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
-from uuid import uuid4
-from datetime import datetime
+from sqlalchemy.sql import func
 from app.database import Base
-from app.models import languages
+import uuid
 
 class Source(Base):
     __tablename__ = "sources"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4, index=True)
-    source_language = Column(String(100), nullable=False)
+    source_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     version_name = Column(String(100), nullable=False)
     version_abbreviation = Column(String(100), nullable=False)
-    language_id = Column(UUID(as_uuid=True), ForeignKey("languages.id"), nullable=False)
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow)
+
+    language_id = Column(UUID(as_uuid=True), ForeignKey("languages.id", ondelete="RESTRICT"), nullable=False)
+    language_name = Column(String(100), nullable=False)  # denormalized field
+
+    description = Column(Text)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/BACKEND/app/models/versions.py
+++ b/BACKEND/app/models/versions.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, String, Boolean, DateTime
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import func
+import uuid
+from app.database import Base
+
+class Version(Base):
+    __tablename__ = "versions"
+
+    version_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    version_name = Column(String(100), nullable=False, unique=True)
+    version_abbr = Column(String(20), nullable=False, unique=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now(), server_default=func.now())
+    is_active = Column(Boolean, default=True)

--- a/BACKEND/app/routes/sources.py
+++ b/BACKEND/app/routes/sources.py
@@ -1,0 +1,79 @@
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.orm import Session
+from uuid import UUID
+from app.database import get_db
+from app.schemas.sources import (
+    SourceCreate, SourceUpdate, SourceResponse,
+    SuccessResponse,SuccessListResponse, ErrorResponse
+)
+from app.crud.sources import source_service
+
+router = APIRouter(prefix="/sources", tags=["Sources"])
+
+@router.post(
+    "/",
+    response_model=SuccessResponse,
+    responses={409: {"model": ErrorResponse}},
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a new source"
+)
+def create_source(source: SourceCreate, db: Session = Depends(get_db)):
+    created = source_service.create_source(db, source)
+    return {
+        "message": "Source created successfully.",
+        "data": created
+    }
+
+@router.get(
+    "/{source_id}",
+    response_model=SuccessResponse,
+    responses={404: {"model": ErrorResponse}},
+    summary="Fetch a source by ID"
+)
+def read_source(source_id: UUID, db: Session = Depends(get_db)):
+    source = source_service.get_source(db, source_id)
+    return {
+        "message": "Source fetched successfully.",
+        "data": source
+    }
+
+@router.get(
+    "/",
+    response_model=SuccessListResponse,
+    summary="Fetch all sources"
+)
+def read_sources(db: Session = Depends(get_db)):
+    sources = source_service.get_all_sources(db)
+    msg = "Sources fetched successfully." if sources else "No sources found."
+    return {
+        "message": msg,
+        "data": sources
+    }
+
+
+@router.put(
+    "/{source_id}",
+    response_model=SuccessResponse,
+    responses={404: {"model": ErrorResponse}},
+    summary="Update a source by ID"
+)
+def update_source(source_id: UUID, update: SourceUpdate, db: Session = Depends(get_db)):
+    updated = source_service.update_source(db, source_id, update)
+    return {
+        "message": "Source updated successfully.",
+        "data": updated
+    }
+
+@router.delete(
+    "/{source_id}",
+    response_model=SuccessResponse,
+    responses={404: {"model": ErrorResponse}},
+    status_code=status.HTTP_200_OK,
+    summary="Delete a source by ID"
+)
+def delete_source(source_id: UUID, db: Session = Depends(get_db)):
+    deleted = source_service.delete_source(db, source_id)
+    return {
+        "message": f"Source with ID {source_id} deleted successfully.",
+        "data": deleted
+    }

--- a/BACKEND/app/routes/sources.py
+++ b/BACKEND/app/routes/sources.py
@@ -31,7 +31,7 @@ def create_source(source: SourceCreate, db: Session = Depends(get_db)):
     summary="Fetch a source by ID"
 )
 def read_source(source_id: UUID, db: Session = Depends(get_db)):
-    source = source_service.get_source(db, source_id)
+    source = source_service.get_source_by_id(db, source_id)
     return {
         "message": "Source fetched successfully.",
         "data": source

--- a/BACKEND/app/routes/sources.py
+++ b/BACKEND/app/routes/sources.py
@@ -44,11 +44,31 @@ def read_source(source_id: UUID, db: Session = Depends(get_db)):
 )
 def read_sources(db: Session = Depends(get_db)):
     sources = source_service.get_all_sources(db)
+    source_responses = [SourceResponse.from_orm(src) for src in sources]
     msg = "Sources fetched successfully." if sources else "No sources found."
     return {
         "message": msg,
-        "data": sources
+        "data": source_responses
     }
+@router.get(
+    "/by_version_name/{version_name}",
+    response_model=SuccessListResponse,
+    responses={404: {"model": ErrorResponse}},
+    summary="Fetch all sources by version name"
+)
+def get_sources_by_version_name(version_name: str, db: Session = Depends(get_db)):
+    sources = source_service.get_sources_by_version_name(db, version_name)
+    if not sources:
+        return {
+            "message": f"No sources found for version_name '{version_name}'.",
+            "data": []
+        }
+    source_responses = [SourceResponse.from_orm(src) for src in sources]
+    return {
+        "message": "Sources fetched successfully.",
+        "data": source_responses
+    }
+
 
 
 @router.put(

--- a/BACKEND/app/routes/sources.py
+++ b/BACKEND/app/routes/sources.py
@@ -8,7 +8,7 @@ from app.schemas.sources import (
 )
 from app.crud.sources import source_service
 
-router = APIRouter(prefix="/sources", tags=["Sources"])
+router = APIRouter(tags=["sources"])
 
 @router.post(
     "/",

--- a/BACKEND/app/schemas/sources.py
+++ b/BACKEND/app/schemas/sources.py
@@ -1,0 +1,39 @@
+from pydantic import BaseModel, UUID4
+from datetime import datetime
+from typing import Optional
+from typing import List
+
+
+class SourceBase(BaseModel):
+    source_language: str
+    version_name: str
+    version_abbreviation: str
+    language_id: UUID4
+
+class SourceCreate(SourceBase):
+    pass
+
+class SourceUpdate(BaseModel):
+    source_language: Optional[str] = None
+    version_name: Optional[str] = None
+    version_abbreviation: Optional[str] = None
+    language_id: Optional[UUID4] = None
+
+
+class SourceResponse(SourceBase):
+    id: UUID4
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True
+
+class SuccessResponse(BaseModel):
+    message: str
+    data: SourceResponse
+
+class ErrorResponse(BaseModel):
+    message: str
+class SuccessListResponse(BaseModel):
+    message: str
+    data: List[SourceResponse]

--- a/BACKEND/app/schemas/sources.py
+++ b/BACKEND/app/schemas/sources.py
@@ -3,9 +3,8 @@ from typing import Optional
 from datetime import datetime
 
 class SourceCreate(BaseModel):
-    version_name: str
-    version_abbreviation: str
     language_id: UUID4
+    version_id: UUID4
     description: Optional[str] = None
 
 class SourceUpdate(BaseModel):
@@ -16,16 +15,17 @@ class SourceUpdate(BaseModel):
 
 class SourceResponse(BaseModel):
     source_id: UUID4
-    version_name: str
-    version_abbreviation: str
+    version_id: UUID4
     language_id: UUID4
     language_name: str
+    version_id: UUID4
+    version_name: str
     description: Optional[str]
     created_at: datetime
     updated_at: datetime
 
     class Config:
-        from_attributes = True
+        orm_mode = True
 
 class SuccessResponse(BaseModel):
     message: str

--- a/BACKEND/app/schemas/sources.py
+++ b/BACKEND/app/schemas/sources.py
@@ -1,39 +1,39 @@
 from pydantic import BaseModel, UUID4
-from datetime import datetime
 from typing import Optional
-from typing import List
+from datetime import datetime
 
-
-class SourceBase(BaseModel):
-    source_language: str
+class SourceCreate(BaseModel):
     version_name: str
     version_abbreviation: str
     language_id: UUID4
-
-class SourceCreate(SourceBase):
-    pass
+    description: Optional[str] = None
 
 class SourceUpdate(BaseModel):
-    source_language: Optional[str] = None
     version_name: Optional[str] = None
     version_abbreviation: Optional[str] = None
     language_id: Optional[UUID4] = None
+    description: Optional[str] = None
 
-
-class SourceResponse(SourceBase):
-    id: UUID4
+class SourceResponse(BaseModel):
+    source_id: UUID4
+    version_name: str
+    version_abbreviation: str
+    language_id: UUID4
+    language_name: str
+    description: Optional[str]
     created_at: datetime
     updated_at: datetime
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 class SuccessResponse(BaseModel):
     message: str
     data: SourceResponse
 
-class ErrorResponse(BaseModel):
-    message: str
 class SuccessListResponse(BaseModel):
     message: str
-    data: List[SourceResponse]
+    data: list[SourceResponse]
+
+class ErrorResponse(BaseModel):
+    detail: str

--- a/BACKEND/app/tests/test_sources.py
+++ b/BACKEND/app/tests/test_sources.py
@@ -40,7 +40,6 @@ def generate_source(language_id):
         "language_id": language_id
     }
 
-
 def test_create_source_success():
     lang_id = create_fake_language_id()
     source = generate_source(lang_id)
@@ -77,7 +76,8 @@ def test_update_source_partial_success():
     lang_id = create_fake_language_id()
     source = generate_source(lang_id)
     created = client.post("/sources/", json=source).json()["data"]
-    source_id = created["id"]
+    source_id = created["source_id"]  # fixed
+
 
     update_payload = {"version_name": "Updated Version"}
     response = client.put(f"/sources/{source_id}", json=update_payload)
@@ -88,17 +88,17 @@ def test_get_source_by_id():
     lang_id = create_fake_language_id()
     source = generate_source(lang_id)
     created = client.post("/sources/", json=source).json()["data"]
-    source_id = created["id"]
+    source_id = created["source_id"]
 
     response = client.get(f"/sources/{source_id}")
     assert response.status_code == 200
-    assert response.json()["data"]["id"] == source_id
+    assert response.json()["data"]["source_id"] == source_id
 
 def test_delete_source_success():
     lang_id = create_fake_language_id()
     source = generate_source(lang_id)
     created = client.post("/sources/", json=source).json()["data"]
-    source_id = created["id"]
+    source_id = created["source_id"]
 
     response = client.delete(f"/sources/{source_id}")
     assert response.status_code == 200

--- a/BACKEND/app/tests/test_sources.py
+++ b/BACKEND/app/tests/test_sources.py
@@ -6,16 +6,59 @@ from app.main import app
 from app.database import SessionLocal
 
 client = TestClient(app)
+
 @pytest.fixture(autouse=True)
 def cleanup_sources_and_languages():
     """
-    Automatically runs before and after each test to clean up test sources and languages.
+    Runs before and after each test to clean up test data.
     """
-    yield  # Run the test
+    yield  # run the test
     db = SessionLocal()
     try:
-        db.execute(text("DELETE FROM sources WHERE version_name LIKE 'Test%' OR version_name LIKE 'Updated%'"))
-        db.execute(text("DELETE FROM languages WHERE name = 'TestLang'"))
+        # Clean dependent tables respecting FK constraints
+        db.execute(text("""
+            DELETE FROM verses 
+            WHERE chapter_id IN (
+                SELECT chapter_id FROM chapters 
+                WHERE book_id IN (
+                    SELECT book_id FROM books 
+                    WHERE source_id IN (
+                        SELECT source_id FROM sources 
+                        WHERE version_name LIKE 'Test%' OR version_name LIKE 'Updated%'
+                    )
+                )
+            )
+        """))
+        db.execute(text("""
+            DELETE FROM chapters 
+            WHERE book_id IN (
+                SELECT book_id FROM books 
+                WHERE source_id IN (
+                    SELECT source_id FROM sources 
+                    WHERE version_name LIKE 'Test%' OR version_name LIKE 'Updated%'
+                )
+            )
+        """))
+        db.execute(text("""
+            DELETE FROM books 
+            WHERE source_id IN (
+                SELECT source_id FROM sources 
+                WHERE version_name LIKE 'Test%' OR version_name LIKE 'Updated%'
+            )
+        """))
+        db.execute(text("""
+            DELETE FROM sources 
+            WHERE version_name LIKE 'Test%' OR version_name LIKE 'Updated%'
+        """))
+        db.execute(text("""
+            DELETE FROM languages 
+            WHERE name = 'TestLang'
+        """))
+        db.execute(text("""
+            DELETE FROM versions 
+            WHERE version_name = 'TestVersion'
+        """))
+        db.execute(text("DELETE FROM versions WHERE version_name LIKE 'Test%' OR version_name LIKE 'Updated%'"))
         db.commit()
     finally:
         db.close()
@@ -24,85 +67,119 @@ def create_fake_language_id():
     db = SessionLocal()
     lang_id = str(uuid.uuid4())
     db.execute(
-        text("INSERT INTO languages (id, name, code) VALUES (:id, :name, :code)"),
-        {"id": lang_id, "name": "TestLang", "code": f"t{lang_id[:4]}"}
+        text("""
+            INSERT INTO languages (language_id, name, "ISO_code") 
+            VALUES (:id, :name, :code)
+        """),
+        {"id": lang_id, "name": "TestLang", "code": f"TST{lang_id[:4]}"}
     )
     db.commit()
     db.close()
     return lang_id
 
+def create_fake_version_id():
+    db = SessionLocal()
+    version_id = str(uuid.uuid4())
+    db.execute(
+        text("""
+            INSERT INTO versions (version_id, version_name, version_abbr) 
+            VALUES (:id, :name, :abbr)
+        """),
+        {"id": version_id, "name": "TestVersion", "abbr": "TV"}
+    )
+    db.commit()
+    db.close()
+    return version_id
 
-def generate_source(language_id):
+def generate_source(language_id, version_id):
     return {
-        "source_language": "English",
-        "version_name": "Test Version",
-        "version_abbreviation": "TST",
-        "language_id": language_id
+        "language_id": language_id,
+        "version_id": version_id,
+        "description": "Sample test source"
     }
 
 def test_create_source_success():
     lang_id = create_fake_language_id()
-    source = generate_source(lang_id)
+    ver_id = create_fake_version_id()
+    source = generate_source(lang_id, ver_id)
     response = client.post("/sources/", json=source)
-    assert response.status_code == 201
-    data = response.json()["data"]
-    assert data["version_name"] == source["version_name"]
-    assert data["language_id"] == source["language_id"]
+    assert response.status_code == 201, response.json()
+    data = response.json().get("data")
+    assert data is not None, response.json()
+    assert data["version_id"] == ver_id
+    assert data["language_id"] == lang_id
 
 def test_create_source_invalid_language_id():
-    bad_source = generate_source(language_id="invalid-uuid")
+    ver_id = create_fake_version_id()
+    bad_source = generate_source(language_id="invalid-uuid", version_id=ver_id)
     response = client.post("/sources/", json=bad_source)
-    assert response.status_code == 422  # UUID parsing error
+    assert response.status_code == 422, response.json()
 
 def test_create_source_nonexistent_language_id():
+    ver_id = create_fake_version_id()
     fake_lang_id = str(uuid.uuid4())
-    bad_source = generate_source(fake_lang_id)
+    bad_source = generate_source(language_id=fake_lang_id, version_id=ver_id)
     response = client.post("/sources/", json=bad_source)
-    assert response.status_code == 404
-    assert "Language with ID" in response.json()["detail"]
+    assert response.status_code == 404, response.json()
+    assert "Language with ID" in response.json().get("detail", "")
 
 def test_create_source_missing_fields():
     lang_id = create_fake_language_id()
-    bad_source = {"version_name": "Test Version", "language_id": lang_id}
+    # Missing version_id intentionally to trigger validation error
+    bad_source = {
+        "language_id": lang_id,
+        "description": "Missing version_id"
+    }
     response = client.post("/sources/", json=bad_source)
-    assert response.status_code == 422
+    assert response.status_code == 422, response.json()
 
 def test_get_all_sources():
     response = client.get("/sources/")
-    assert response.status_code == 200
-    assert isinstance(response.json()["data"], list)
+    assert response.status_code == 200, response.json()
+    data = response.json().get("data")
+    assert isinstance(data, list)
 
 def test_update_source_partial_success():
     lang_id = create_fake_language_id()
-    source = generate_source(lang_id)
-    created = client.post("/sources/", json=source).json()["data"]
-    source_id = created["source_id"]  # fixed
+    ver_id = create_fake_version_id()
+    source = generate_source(lang_id, ver_id)
+    create_resp = client.post("/sources/", json=source)
+    assert create_resp.status_code == 201, create_resp.json()
+    created = create_resp.json().get("data")
+    source_id = created["source_id"]
 
-
-    update_payload = {"version_name": "Updated Version"}
+    update_payload = {"description": "Updated description"}
     response = client.put(f"/sources/{source_id}", json=update_payload)
-    assert response.status_code == 200
-    assert response.json()["data"]["version_name"] == "Updated Version"
+    assert response.status_code == 200, response.json()
+    data = response.json().get("data")
+    assert data["description"] == "Updated description"
 
 def test_get_source_by_id():
     lang_id = create_fake_language_id()
-    source = generate_source(lang_id)
-    created = client.post("/sources/", json=source).json()["data"]
+    ver_id = create_fake_version_id()
+    source = generate_source(lang_id, ver_id)
+    create_resp = client.post("/sources/", json=source)
+    assert create_resp.status_code == 201, create_resp.json()
+    created = create_resp.json().get("data")
     source_id = created["source_id"]
 
     response = client.get(f"/sources/{source_id}")
-    assert response.status_code == 200
-    assert response.json()["data"]["source_id"] == source_id
+    assert response.status_code == 200, response.json()
+    data = response.json().get("data")
+    assert data["source_id"] == source_id
 
 def test_delete_source_success():
     lang_id = create_fake_language_id()
-    source = generate_source(lang_id)
-    created = client.post("/sources/", json=source).json()["data"]
+    ver_id = create_fake_version_id()
+    source = generate_source(lang_id, ver_id)
+    create_resp = client.post("/sources/", json=source)
+    assert create_resp.status_code == 201, create_resp.json()
+    created = create_resp.json().get("data")
     source_id = created["source_id"]
 
     response = client.delete(f"/sources/{source_id}")
-    assert response.status_code == 200
-    assert "deleted successfully" in response.json()["message"]
+    assert response.status_code == 200, response.json()
+    assert "deleted successfully" in response.json().get("message", "").lower()
 
     # Confirm deletion
     response = client.get(f"/sources/{source_id}")
@@ -112,3 +189,44 @@ def test_delete_nonexistent_source():
     fake_id = str(uuid.uuid4())
     response = client.delete(f"/sources/{fake_id}")
     assert response.status_code == 404
+def test_create_duplicate_source_should_fail():
+    db = SessionLocal()
+    
+    # Create language
+    lang_id = str(uuid.uuid4())
+    db.execute(
+        text("""
+            INSERT INTO languages (language_id, name, "ISO_code") 
+            VALUES (:id, :name, :code)
+        """),
+        {"id": lang_id, "name": "TestLang", "code": f"TST{lang_id[:4]}"}
+    )
+    
+    # Create version
+    version_id = str(uuid.uuid4())
+    db.execute(
+        text("""
+            INSERT INTO versions (version_id, version_name, version_abbr) 
+            VALUES (:id, :name, :abbr)
+        """),
+        {"id": version_id, "name": "TestVersion", "abbr": "TV"}
+    )
+    db.commit()
+    db.close()
+
+    # First create source (should succeed)
+    payload = {
+        "language_id": lang_id,
+        "version_id": version_id,
+        "version_name": "Test Version",
+        "version_abbreviation": "TST",
+        "source_language": "English",
+        "description": "First test source"
+    }
+    response1 = client.post("/sources/", json=payload)
+    assert response1.status_code == 201
+
+    # Try creating the same source again (should fail)
+    response2 = client.post("/sources/", json=payload)
+    assert response2.status_code == 400
+    assert "already exists" in response2.json()["detail"]

--- a/BACKEND/app/tests/test_sources.py
+++ b/BACKEND/app/tests/test_sources.py
@@ -1,0 +1,114 @@
+import uuid
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+from app.main import app
+from app.database import SessionLocal
+
+client = TestClient(app)
+@pytest.fixture(autouse=True)
+def cleanup_sources_and_languages():
+    """
+    Automatically runs before and after each test to clean up test sources and languages.
+    """
+    yield  # Run the test
+    db = SessionLocal()
+    try:
+        db.execute(text("DELETE FROM sources WHERE version_name LIKE 'Test%' OR version_name LIKE 'Updated%'"))
+        db.execute(text("DELETE FROM languages WHERE name = 'TestLang'"))
+        db.commit()
+    finally:
+        db.close()
+
+def create_fake_language_id():
+    db = SessionLocal()
+    lang_id = str(uuid.uuid4())
+    db.execute(
+        text("INSERT INTO languages (id, name, code) VALUES (:id, :name, :code)"),
+        {"id": lang_id, "name": "TestLang", "code": f"t{lang_id[:4]}"}
+    )
+    db.commit()
+    db.close()
+    return lang_id
+
+
+def generate_source(language_id):
+    return {
+        "source_language": "English",
+        "version_name": "Test Version",
+        "version_abbreviation": "TST",
+        "language_id": language_id
+    }
+
+
+def test_create_source_success():
+    lang_id = create_fake_language_id()
+    source = generate_source(lang_id)
+    response = client.post("/sources/", json=source)
+    assert response.status_code == 201
+    data = response.json()["data"]
+    assert data["version_name"] == source["version_name"]
+    assert data["language_id"] == source["language_id"]
+
+def test_create_source_invalid_language_id():
+    bad_source = generate_source(language_id="invalid-uuid")
+    response = client.post("/sources/", json=bad_source)
+    assert response.status_code == 422  # UUID parsing error
+
+def test_create_source_nonexistent_language_id():
+    fake_lang_id = str(uuid.uuid4())
+    bad_source = generate_source(fake_lang_id)
+    response = client.post("/sources/", json=bad_source)
+    assert response.status_code == 404
+    assert "Language with ID" in response.json()["detail"]
+
+def test_create_source_missing_fields():
+    lang_id = create_fake_language_id()
+    bad_source = {"version_name": "Test Version", "language_id": lang_id}
+    response = client.post("/sources/", json=bad_source)
+    assert response.status_code == 422
+
+def test_get_all_sources():
+    response = client.get("/sources/")
+    assert response.status_code == 200
+    assert isinstance(response.json()["data"], list)
+
+def test_update_source_partial_success():
+    lang_id = create_fake_language_id()
+    source = generate_source(lang_id)
+    created = client.post("/sources/", json=source).json()["data"]
+    source_id = created["id"]
+
+    update_payload = {"version_name": "Updated Version"}
+    response = client.put(f"/sources/{source_id}", json=update_payload)
+    assert response.status_code == 200
+    assert response.json()["data"]["version_name"] == "Updated Version"
+
+def test_get_source_by_id():
+    lang_id = create_fake_language_id()
+    source = generate_source(lang_id)
+    created = client.post("/sources/", json=source).json()["data"]
+    source_id = created["id"]
+
+    response = client.get(f"/sources/{source_id}")
+    assert response.status_code == 200
+    assert response.json()["data"]["id"] == source_id
+
+def test_delete_source_success():
+    lang_id = create_fake_language_id()
+    source = generate_source(lang_id)
+    created = client.post("/sources/", json=source).json()["data"]
+    source_id = created["id"]
+
+    response = client.delete(f"/sources/{source_id}")
+    assert response.status_code == 200
+    assert "deleted successfully" in response.json()["message"]
+
+    # Confirm deletion
+    response = client.get(f"/sources/{source_id}")
+    assert response.status_code == 404
+
+def test_delete_nonexistent_source():
+    fake_id = str(uuid.uuid4())
+    response = client.delete(f"/sources/{fake_id}")
+    assert response.status_code == 404


### PR DESCRIPTION
This PR adds full CRUD support for managing Bible sources in the system. Each source is linked to a specific language via a foreign key relationship (language_id), with automatic fetch of the language_name field for denormalized read access.

### Key Features
- Create Source: Validates language_id, auto-fetches and stores language_name.
- Get by ID / List All: Retrieve source(s) with associated language info.
- Update Source: Supports partial updates, updates language_name if language_id changes.
- Delete Source: Removes a source safely by ID
### Validation
- Rejects invalid or missing language_id.
- Enforces required fields: version_name, version_abbreviation, language_id.
###  Tests
- Full test coverage using Pytest:
- Valid/invalid creation
- Read, update, delete operations
- Constraint and error validations
### Screenshots for reference:
<img width="1649" height="929" alt="Screenshot from 2025-07-29 17-07-52" src="https://github.com/user-attachments/assets/3cd4b19b-de91-4729-a858-e61b68816bea" />
<img width="1649" height="929" alt="Screenshot from 2025-07-29 17-07-37" src="https://github.com/user-attachments/assets/3df983a3-f5d9-4315-9174-7b209654c048" />
<img width="1649" height="908" alt="Screenshot from 2025-07-29 17-07-18" src="https://github.com/user-attachments/assets/975b343a-082e-4521-a9dc-75df213b0734" />
<img width="1649" height="908" alt="Screenshot from 2025-07-29 17-06-19" src="https://github.com/user-attachments/assets/b9e83531-a2b2-49c1-a7b7-c54c9377eee8" />
<img width="1649" height="682" alt="Screenshot from 2025-07-29 17-05-45" src="https://github.com/user-attachments/assets/1e2309d5-2a33-4d5a-b01e-ddcc137da687" />
<img width="1920" height="1080" alt="Screenshot from 2025-07-29 17-04-58" src="https://github.com/user-attachments/assets/30af346b-9139-472c-aef5-a3668002fd4b" />
